### PR TITLE
Add infrastructure network types

### DIFF
--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -1,6 +1,10 @@
 - table:
     schema: infrastructure_network
-    name: infrastructure_link
+    name: infrastructure_links
+  object_relationships:
+  - name: infrastructure_network_type
+    using:
+      foreign_key_constraint_on: infrastructure_network_type_id
   insert_permissions:
   - role: anonymous
     permission:
@@ -21,6 +25,43 @@
     permission:
       columns:
       - infrastructure_link_geog
+      filter: {}
+      check: {}
+  delete_permissions:
+  - role: anonymous
+    permission:
+      filter: {}
+- table:
+    schema: infrastructure_network
+    name: infrastructure_network_types
+  array_relationships:
+  - name: infrastructure_links
+    using:
+      foreign_key_constraint_on:
+        column: infrastructure_network_type_id
+        table:
+          schema: infrastructure_network
+          name: infrastructure_links
+  insert_permissions:
+  - role: anonymous
+    permission:
+      check: {}
+      columns:
+      - infrastructure_network_type_name
+      backend_only: false
+  select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - infrastructure_network_type_id
+      - infrastructure_network_type_name
+      filter: {}
+      allow_aggregations: true
+  update_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - infrastructure_network_type_name
       filter: {}
       check: {}
   delete_permissions:

--- a/hasura/migrations/1615200305272_init/up.sql
+++ b/hasura/migrations/1615200305272_init/up.sql
@@ -1,6 +1,6 @@
 CREATE SCHEMA infrastructure_network;
 
-CREATE TABLE infrastructure_network.infrastructure_link (
+CREATE TABLE infrastructure_network.infrastructure_links (
   infrastructure_link_id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
   infrastructure_link_geog geography(LinestringZ,4326) NOT NULL
 );

--- a/hasura/migrations/1615209774035_infrastructure_network_types/down.sql
+++ b/hasura/migrations/1615209774035_infrastructure_network_types/down.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS
+  infrastructure_network.infrastructure_network_types
+  CASCADE;
+
+ALTER TABLE IF EXISTS
+  infrastructure_network.infrastructure_links
+  DROP COLUMN IF EXISTS
+  infrastructure_network_type_id
+  CASCADE;

--- a/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
+++ b/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
@@ -31,3 +31,9 @@ ALTER TABLE infrastructure_network.infrastructure_links
 COMMENT ON COLUMN
   infrastructure_network.infrastructure_links.infrastructure_network_type_id IS
   'The ID of the infrastructure network type describing this link.';
+
+CREATE INDEX
+  infrastructure_links_infrastructure_network_type_id_fkey
+  ON
+  infrastructure_network.infrastructure_links
+  (infrastructure_network_type_id);

--- a/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
+++ b/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
@@ -7,3 +7,18 @@ COMMENT ON COLUMN
 COMMENT ON COLUMN
   infrastructure_network.infrastructure_links.infrastructure_link_geog IS
   'The PostGIS geography of the infrastructure link in WGS 84.';
+
+CREATE TABLE infrastructure_network.infrastructure_network_types (
+  infrastructure_network_type_id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  infrastructure_network_type_name text NOT NULL UNIQUE
+);
+
+COMMENT ON TABLE
+  infrastructure_network.infrastructure_network_types IS
+  'The types of the infrastructure network, e.g. road, rail, tram, metro. Not in Transmodel.';
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_network_types.infrastructure_network_type_id IS
+  'The ID of the infrastructure network type.';
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_network_types.infrastructure_network_type_name IS
+  'The name of the infrastructure network type, e.g. "road", "rail", "tram", "metro".';

--- a/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
+++ b/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
@@ -1,0 +1,9 @@
+COMMENT ON TABLE
+  infrastructure_network.infrastructure_links IS
+  'The infrastructure links, e.g. road or rail segments.';
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_links.infrastructure_link_id IS
+  'The ID of the infrastructure link.';
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_links.infrastructure_link_geog IS
+  'The PostGIS geography of the infrastructure link in WGS 84.';

--- a/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
+++ b/hasura/migrations/1615209774035_infrastructure_network_types/up.sql
@@ -22,3 +22,12 @@ COMMENT ON COLUMN
 COMMENT ON COLUMN
   infrastructure_network.infrastructure_network_types.infrastructure_network_type_name IS
   'The name of the infrastructure network type, e.g. "road", "rail", "tram", "metro".';
+
+ALTER TABLE infrastructure_network.infrastructure_links
+  ADD COLUMN infrastructure_network_type_id uuid
+  NOT NULL
+  REFERENCES infrastructure_network.infrastructure_network_types
+  (infrastructure_network_type_id);
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_links.infrastructure_network_type_id IS
+  'The ID of the infrastructure network type describing this link.';


### PR DESCRIPTION
- Pluralize table name (Cheating a bit but we get to practice migrations in the following commits.)
- Add comments for table infrastructure_links (Also, these could have been in another migration.)
- Add table infrastructure_network_types
- Connect infrastructure link and network type
- Add index for the foreign key
- Add down migration
- Update metadata

Maybe later we'll squash these migrations before starting to insert data so that the initial migration files stay more readable.
But now we'll get to practice migrations.
