### PR TITLE
Add infrastructure points

### DIFF
--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -5,6 +5,12 @@
   - name: infrastructure_network_type
     using:
       foreign_key_constraint_on: infrastructure_network_type_id
+  - name: infrastructurePointByInfrastructureBeginPointId
+    using:
+      foreign_key_constraint_on: infrastructure_begin_point_id
+  - name: infrastructurePointByInfrastructureEndPointId
+    using:
+      foreign_key_constraint_on: infrastructure_end_point_id
   insert_permissions:
   - role: anonymous
     permission:
@@ -16,8 +22,11 @@
   - role: anonymous
     permission:
       columns:
-      - infrastructure_link_geog
       - infrastructure_link_id
+      - infrastructure_link_geog
+      - infrastructure_network_type_id
+      - infrastructure_begin_point_id
+      - infrastructure_end_point_id
       filter: {}
       allow_aggregations: true
   update_permissions:

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -68,3 +68,37 @@
   - role: anonymous
     permission:
       filter: {}
+- table:
+    schema: infrastructure_network
+    name: infrastructure_point_types
+  is_enum: true
+  array_relationships:
+  - name: infrastructure_points
+    using:
+      foreign_key_constraint_on:
+        column: infrastructure_point_type
+        table:
+          schema: infrastructure_network
+          name: infrastructure_points
+  select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - infrastructure_point_type_value
+      - infrastructure_point_type_comment
+      filter: {}
+- table:
+    schema: infrastructure_network
+    name: infrastructure_points
+  object_relationships:
+  - name: infrastructurePointTypeByInfrastructurePointType
+    using:
+      foreign_key_constraint_on: infrastructure_point_type
+  select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - infrastructure_point_id
+      - infrastructure_point_type
+      - infrastructure_point_geom
+      filter: {}

--- a/hasura/migrations/1616397265804_add_infrastructure_point/down.sql
+++ b/hasura/migrations/1616397265804_add_infrastructure_point/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS infrastructure_network.infrastructure_points;
+DROP TABLE IF EXISTS infrastructure_network.infrastructure_point_types;

--- a/hasura/migrations/1616397265804_add_infrastructure_point/up.sql
+++ b/hasura/migrations/1616397265804_add_infrastructure_point/up.sql
@@ -1,0 +1,39 @@
+CREATE TABLE infrastructure_network.infrastructure_point_types (
+  infrastructure_point_type_value TEXT PRIMARY KEY,
+  infrastructure_point_type_comment TEXT NOT NULL
+);
+
+COMMENT ON TABLE infrastructure_network.infrastructure_point_types IS 'The enum types of the infrastructure point. The enum type is not part of Transmodel.';
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_point_types.infrastructure_point_type_value IS
+  'The short ID of the infrastructure point type. The enum type is not part of Transmodel. Using length of one byte will likely be adequate in JORE context but it is not enforced.';
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_point_types.infrastructure_point_type_comment IS
+  'The long name of the infrastructure point type.';
+
+INSERT INTO infrastructure_network.infrastructure_point_types
+  (infrastructure_point_type_value, infrastructure_point_type_comment)
+  VALUES
+  ('S', 'Stop'),
+  ('X', 'Crossroads/Junction'),
+  ('B', 'Border between municipalities');
+
+CREATE TABLE infrastructure_network.infrastructure_points (
+  infrastructure_point_id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  infrastructure_point_type TEXT NOT NULL
+    REFERENCES infrastructure_network.infrastructure_point_types (infrastructure_point_type_value)
+);
+
+SELECT AddGeometryColumn('infrastructure_network', 'infrastructure_points', 'infrastructure_point_geom', 4326, 'POINT', 3);
+
+ALTER TABLE infrastructure_network.infrastructure_points ALTER COLUMN infrastructure_point_geom SET NOT NULL;
+
+CREATE INDEX ON infrastructure_network.infrastructure_points (infrastructure_point_type);
+
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_points.infrastructure_point_type IS
+  'The infrastructure point type describing this point.';
+
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_points.infrastructure_point_geom IS
+  'WGS84 point geometry (single coordinate) describing location of infrastructure point.';

--- a/hasura/migrations/1616590660107_associate_infrastructure_links_with_points/down.sql
+++ b/hasura/migrations/1616590660107_associate_infrastructure_links_with_points/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE infrastructure_network.infrastructure_links DROP COLUMN infrastructure_begin_point_id;
+ALTER TABLE infrastructure_network.infrastructure_links DROP COLUMN infrastructure_end_point_id;

--- a/hasura/migrations/1616590660107_associate_infrastructure_links_with_points/up.sql
+++ b/hasura/migrations/1616590660107_associate_infrastructure_links_with_points/up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE infrastructure_network.infrastructure_links
+  ADD COLUMN infrastructure_begin_point_id uuid NOT NULL
+  REFERENCES infrastructure_network.infrastructure_points (infrastructure_point_id);
+
+ALTER TABLE infrastructure_network.infrastructure_links
+  ADD COLUMN infrastructure_end_point_id uuid NOT NULL
+  REFERENCES infrastructure_network.infrastructure_points (infrastructure_point_id);
+
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_links.infrastructure_begin_point_id IS
+  'The ID of the begin point of infrastructure link.';
+
+COMMENT ON COLUMN
+  infrastructure_network.infrastructure_links.infrastructure_end_point_id IS
+  'The ID of the end point of infrastructure link.';
+
+CREATE INDEX ON infrastructure_network.infrastructure_links (infrastructure_begin_point_id);
+CREATE INDEX ON infrastructure_network.infrastructure_links (infrastructure_end_point_id);


### PR DESCRIPTION
Introducing intrastructure points into database schema. Currently, it is uncertain whether we actually need to have infra points in a dedicated database table. However, having infrastructure points helps in importing data from Jore3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-sql-schema-experiment/15)
<!-- Reviewable:end -->
